### PR TITLE
Call the correct constructor in rake tasks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,8 @@ jobs:
         with:
           ruby-version: '3.4'
           bundler-cache: true
+      - name: Verify gem builds
+        run: gem build --strict --verbose *.gemspec
       - id: ruby
         uses: voxpupuli/ruby-version@v1
   test:
@@ -35,14 +37,14 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
+      - name: Verify gem builds
+        run: gem build --strict --verbose *.gemspec
       - name: check that required tasks are available
         run: |
           bundle exec rake --rakefile lib/puppet_fixtures/tasks.rb -T 'fixtures:clean' | grep --quiet .
           bundle exec rake --rakefile lib/puppet_fixtures/tasks.rb -T 'fixtures:prep' | grep --quiet .
       - name: Run rspec tests
         run: bundle exec rake spec
-      - name: Verify gem builds
-        run: gem build --strict --verbose *.gemspec
 
   tests:
     needs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,12 +39,11 @@ jobs:
           bundler-cache: true
       - name: Verify gem builds
         run: gem build --strict --verbose *.gemspec
-      - name: check that required tasks are available
-        run: |
-          bundle exec rake --rakefile lib/puppet_fixtures/tasks.rb -T 'fixtures:clean' | grep --quiet .
-          bundle exec rake --rakefile lib/puppet_fixtures/tasks.rb -T 'fixtures:prep' | grep --quiet .
       - name: Run rspec tests
         run: bundle exec rake spec
+      - name: Run acceptance tests
+        run: |
+          bundle exec rake --rakefile lib/puppet_fixtures/tasks.rb fixtures:prep fixtures:clean
 
   tests:
     needs:

--- a/lib/puppet_fixtures/tasks.rb
+++ b/lib/puppet_fixtures/tasks.rb
@@ -5,11 +5,11 @@ require 'rake'
 namespace :fixtures do
   desc 'Create the fixtures directory'
   task :prep do
-    PuppetFixtures.new.download(max_thread_limit: ENV.fetch('MAX_FIXTURE_THREAD_COUNT', 10).to_i)
+    PuppetFixtures::Fixtures.new(max_thread_limit: ENV.fetch('MAX_FIXTURE_THREAD_COUNT', 10).to_i).download
   end
 
   desc 'Clean up the fixtures directory'
   task :clean do
-    PuppetFixtures.new.clean
+    PuppetFixtures::Fixtures.new.clean
   end
 end


### PR DESCRIPTION
This adds basic acceptance tests by running the rake tasks. By default they should be noop since there is no fixture file.

In addition it verifies gem builds first. This is a very cheap test and we should run the cheapest test first. It's run twice  now: first before setting up the matrix to avoid running an entire matrix build on broken code. Then in very test again to     account for differences in Ruby version verification.

Fixes: 4557f8fe366882d8c11e6cf4d3a0cca62088d5c9 ("Refactor to a separate class")