### PR TITLE
Refactor OpenVox/Puppet version detection for easier testing

### DIFF
--- a/lib/puppet_fixtures.rb
+++ b/lib/puppet_fixtures.rb
@@ -267,22 +267,21 @@ module PuppetFixtures
 
     private
 
+    def gem_version(name)
+      Gem::Specification.find_by_name(name).version.to_s
+    rescue Gem::LoadError
+      nil
+    end
+
     def include_repo?(version_range)
       return true unless version_range
 
+      puppet_version = gem_version('openvox') || gem_version('puppet')
+      raise "Neither 'openvox' nor 'puppet' gem could be found. Please install one of them." unless puppet_version
+
       require 'semantic_puppet'
 
-      puppet_spec = begin
-        Gem::Specification.find_by_name('openvox')
-      rescue Gem::LoadError
-        begin
-          Gem::Specification.find_by_name('puppet')
-        rescue Gem::LoadError
-          raise "Neither 'openvox' nor 'puppet' gem could be found. Please install one of them."
-        end
-      end
-      puppet_version = SemanticPuppet::Version.parse(puppet_spec.version.to_s)
-
+      puppet_version = SemanticPuppet::Version.parse(puppet_version)
       constraint = SemanticPuppet::VersionRange.parse(version_range)
       constraint.include?(puppet_version)
     end

--- a/puppet_fixtures.gemspec
+++ b/puppet_fixtures.gemspec
@@ -15,5 +15,4 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.7', '< 4'
 
   s.add_dependency 'rake', '~> 13.0'
-  s.add_dependency 'ostruct', '~> 0.6.0'
 end

--- a/spec/puppet_fixtures/fixtures_spec.rb
+++ b/spec/puppet_fixtures/fixtures_spec.rb
@@ -1,6 +1,5 @@
 require 'spec_helper'
 require 'tmpdir'
-require 'ostruct'
 
 describe PuppetFixtures::Fixtures do
   subject(:instance) { described_class.new(source_dir: source_dir) }
@@ -56,43 +55,41 @@ describe PuppetFixtures::Fixtures do
     it { is_expected.to eq({}) }
   end
 
-  describe '#include_repo?' do
-    before do
-      stub_const('Gem::Specification', Class.new do
-        def self.find_by_name(name)
-          case name
-          when 'openvox'
-            OpenStruct.new(version: '7.0.0')
-          when 'puppet'
-            OpenStruct.new(version: '6.0.0')
-          else
-            raise Gem::LoadError
-          end
-        end
-      end)
-      require 'semantic_puppet'
+  describe '#gem_version' do
+    it 'returns nil if a gem is not found' do
+      expect(fixtures.send(:gem_version, 'does-not-exist')).to be_nil
     end
 
+    it 'returns a string if a gem is found' do
+      expect(fixtures.send(:gem_version, 'puppet_fixtures')).to be_instance_of(String)
+    end
+  end
+
+  describe '#include_repo?' do
     it 'returns true if version_range is nil' do
+      expect(fixtures).not_to receive(:gem_version)
       expect(fixtures.send(:include_repo?, nil)).to eq(true)
     end
 
     it 'returns true if puppet version matches the range' do
+      expect(fixtures).to receive(:gem_version).with('openvox').and_return('7.0.0')
       expect(fixtures.send(:include_repo?, '>= 6.0.0')).to eq(true)
     end
 
     it 'returns false if puppet version does not match the range' do
+      expect(fixtures).to receive(:gem_version).with('openvox').and_return('7.0.0')
       expect(fixtures.send(:include_repo?, '< 6.0.0')).to eq(false)
     end
 
     it 'falls back to puppet gem if openvox is not found' do
-      allow(Gem::Specification).to receive(:find_by_name).with('openvox').and_raise(Gem::LoadError)
-      allow(Gem::Specification).to receive(:find_by_name).with('puppet').and_return(OpenStruct.new(version: '6.0.0'))
+      expect(fixtures).to receive(:gem_version).with('openvox').and_return(nil)
+      expect(fixtures).to receive(:gem_version).with('puppet').and_return('6.0.0')
       expect(fixtures.send(:include_repo?, '>= 6.0.0')).to eq(true)
     end
 
     it 'raises if neither openvox nor puppet gem is found' do
-      allow(Gem::Specification).to receive(:find_by_name).and_raise(Gem::LoadError)
+      expect(fixtures).to receive(:gem_version).with('openvox').and_return(nil)
+      expect(fixtures).to receive(:gem_version).with('puppet').and_return(nil)
       expect {
         fixtures.send(:include_repo?, '>= 6.0.0')
       }.to raise_error(RuntimeError, /Neither 'openvox' nor 'puppet' gem could be found/)


### PR DESCRIPTION
ca14b912ea698d320a485f37dd13ded1c7e45121 added ostruct as a dependency, but this refactors the code with a gem_version method that can be easily stubbed. The result is code that is easier to read and test.