### PR TITLE
Add fileutils require statement

### DIFF
--- a/lib/puppet_fixtures.rb
+++ b/lib/puppet_fixtures.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'fileutils'
 require 'json'
 require 'open3'
 require 'yaml'


### PR DESCRIPTION
While in most cases this is already required by rake, it's not guaranteed.

To reproduce, I used the following fixture content in `.fixtures.yml`:
```yaml
---
fixtures:
  repositories:
    auditbeat:
      repo: 'https://github.com/bastelfreak/norisnetwork-auditbeat'
      ref: '938a95ed21a8ec66e3e8a7acd27a762904d28565'
```

Then running `bundle exec puppet-fixtures install` triggered it.