### PR TITLE
Add tmpdir require statement

### DIFF
--- a/lib/puppet_fixtures.rb
+++ b/lib/puppet_fixtures.rb
@@ -3,6 +3,7 @@
 require 'fileutils'
 require 'json'
 require 'open3'
+require 'tmpdir'
 require 'yaml'
 
 # PuppetFixtures is a mechanism to download Puppet fixtures.


### PR DESCRIPTION
I was testing beaker runs with `configure_beaker(modules: :fixtures)` and a modification to Rakefile to run 'fixtures:prep' before beaker.

Locally with just `BEAKER_SETFILE=rocky8-64 bundle exec rake beaker` this works fine, but in github workflow which use
`BUNDLE_WITHOUT=development:test:release` I get errors like
```
/home/runner/work/spk-forgerock-web-policy-agent/spk-forgerock-web-policy-agent/vendor/bundle/ruby/3.2.0/gems/puppet_fixtures-2.2.2/lib/puppet_fixtures.rb:196:in `download_module': undefined method `mktmpdir' for Dir:Class (NoMethodError)

      Dir.mktmpdir do |working_dir|
         ^^^^^^^^^
Did you mean?  mkdir
```

I guess something else requires this in the 'spec' task that is not part of the 'beaker' task.